### PR TITLE
Fix reconnection to non-localhost server

### DIFF
--- a/src/residue.cc
+++ b/src/residue.cc
@@ -386,7 +386,7 @@ void Residue::dispatch()
             if (!s_loggingClient->connected()) {
                 InternalLogger(InternalLogger::info) << "Trying to connect...";
                 m_connected = false;
-                connect();
+                reconnect();
             }
         } catch (const ResidueException& e) {
             InternalLogger(InternalLogger::error) << "Failed to connect: " << e.what() << ". Retrying in 500ms";


### PR DESCRIPTION
If the server connection dies, reconnect() needs to be called here instead of connect() - otherwise it will only try to reconnect to 127.0.0.1:8777 rather than the host/port supplied in the JSON configuration.